### PR TITLE
stx ceph upgrade

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -982,7 +982,7 @@ ln -sf %{_sbindir}/mount.ceph %{buildroot}/sbin/mount.ceph
 
 # udev rules
 install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
-install -m 0644 -D udev/60-ceph-by-parttypeuuid.rules %{buildroot}%{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
+install -m 0640 -D udev/60-ceph-by-parttypeuuid.rules %{buildroot}%{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
 install -m 0644 -D udev/95-ceph-osd.rules %{buildroot}%{_udevrulesdir}/95-ceph-osd.rules
 
 #set up placeholder directories

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1046,7 +1046,7 @@ rm -rf %{buildroot}
 %{_bindir}/ceph-detect-init
 %{_sysconfdir}/ceph/ceph.conf.pmon
 %{_sysconfdir}/ceph/ceph_pmon_wrapper.sh
-%{_sysconfdir}/ceph/ceph.conf
+%config(noreplace) %{_sysconfdir}/ceph/ceph.conf
 %{_sysconfdir}/services.d/*
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
 %{_sbindir}/ceph-create-keys

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1010,6 +1010,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/services.d/controller
 mkdir -p %{buildroot}%{_sysconfdir}/services.d/storage
 mkdir -p %{buildroot}%{_initrddir}
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
+mkdir -p %{buildroot}%{_unitdir}
 
 install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/controller/
 install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/storage/
@@ -1018,6 +1019,9 @@ install -m 750 wrs/ceph.conf.pmon %{buildroot}%{_sysconfdir}/ceph/
 install -m 750 wrs/ceph_pmon_wrapper.sh %{buildroot}%{_sysconfdir}/ceph/
 install -m 755 wrs/ceph.conf %{buildroot}%{_sysconfdir}/ceph/
 install -m 700 wrs/ceph-manage-journal.py %{buildroot}/usr/sbin/ceph-manage-journal
+install -m 644 wrs/ceph.service $RPM_BUILD_ROOT/%{_unitdir}/ceph.service
+install -m 644 wrs/ceph-rest-api.service $RPM_BUILD_ROOT/%{_unitdir}/ceph-rest-api.service
+install -m 644 wrs/ceph-radosgw.service $RPM_BUILD_ROOT/%{_unitdir}/ceph-radosgw.service
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -1361,6 +1365,9 @@ fi
 %{_mandir}/man8/ceph-mon.8*
 %{_unitdir}/ceph-mon@.service
 %{_unitdir}/ceph-mon.target
+%{_unitdir}/ceph.service
+%{_unitdir}/ceph-rest-api.service
+%{_unitdir}/ceph-radosgw.service
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mon
 
 %post mon

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -14,6 +14,11 @@
 #
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 #
+
+# WRS: Ceph takes long time to generate debuginfo package which is not used
+# so disable it here.
+%define debug_package %{nil}
+
 %bcond_without ocf
 %bcond_with make_check
 %ifarch s390 s390x

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -988,7 +988,8 @@ ln -sf %{_sbindir}/mount.ceph %{buildroot}/sbin/mount.ceph
 # udev rules
 install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 install -m 0640 -D udev/60-ceph-by-parttypeuuid.rules %{buildroot}%{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
-install -m 0644 -D udev/95-ceph-osd.rules %{buildroot}%{_udevrulesdir}/95-ceph-osd.rules
+# Exclude the ceph-osd.rules
+#install -m 0644 -D udev/95-ceph-osd.rules %{buildroot}%{_udevrulesdir}/95-ceph-osd.rules
 
 #set up placeholder directories
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
@@ -1539,7 +1540,8 @@ fi
 %{_sbindir}/ceph-volume-systemd
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
-%{_udevrulesdir}/95-ceph-osd.rules
+# Exclude the ceph-osd.rules
+#%{_udevrulesdir}/95-ceph-osd.rules
 %{_mandir}/man8/ceph-clsinfo.8*
 %{_mandir}/man8/ceph-osd.8*
 %{_mandir}/man8/ceph-bluestore-tool.8*

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1007,8 +1007,8 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
 
-mkdir -p %{buildroot}%{_sysconfdir}/services.d/controller
-mkdir -p %{buildroot}%{_sysconfdir}/services.d/storage
+install -d -m 750 %{buildroot}%{_sysconfdir}/services.d/controller
+install -d -m 750 %{buildroot}%{_sysconfdir}/services.d/storage
 mkdir -p %{buildroot}%{_initrddir}
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
 mkdir -p %{buildroot}%{_unitdir}
@@ -1018,7 +1018,7 @@ install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/storage/
 install -m 750 wrs/ceph-rest-api %{buildroot}%{_initrddir}/
 install -m 750 wrs/ceph.conf.pmon %{buildroot}%{_sysconfdir}/ceph/
 install -m 750 wrs/ceph_pmon_wrapper.sh %{buildroot}%{_sysconfdir}/ceph/
-install -m 755 wrs/ceph.conf %{buildroot}%{_sysconfdir}/ceph/
+install -m 640 wrs/ceph.conf %{buildroot}%{_sysconfdir}/ceph/
 install -m 700 wrs/ceph-manage-journal.py %{buildroot}/usr/sbin/ceph-manage-journal
 install -m 644 wrs/ceph.service $RPM_BUILD_ROOT/%{_unitdir}/ceph.service
 install -m 644 wrs/ceph-rest-api.service $RPM_BUILD_ROOT/%{_unitdir}/ceph-rest-api.service
@@ -1210,7 +1210,7 @@ fi
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin
-%config(noreplace) %{_sysconfdir}/ceph/rbdmap
+%attr(640,root,root) %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
 %if 0%{with python2}
 %{python_sitelib}/ceph_argparse.py*

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1001,6 +1001,19 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
 
+mkdir -p %{buildroot}%{_sysconfdir}/services.d/controller
+mkdir -p %{buildroot}%{_sysconfdir}/services.d/storage
+mkdir -p %{buildroot}%{_initrddir}
+mkdir -p %{buildroot}%{_sysconfdir}/ceph
+
+install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/controller/
+install -m 750 wrs/ceph.sh %{buildroot}%{_sysconfdir}/services.d/storage/
+install -m 750 wrs/ceph-rest-api %{buildroot}%{_initrddir}/
+install -m 750 wrs/ceph.conf.pmon %{buildroot}%{_sysconfdir}/ceph/
+install -m 750 wrs/ceph_pmon_wrapper.sh %{buildroot}%{_sysconfdir}/ceph/
+install -m 755 wrs/ceph.conf %{buildroot}%{_sysconfdir}/ceph/
+install -m 700 wrs/ceph-manage-journal.py %{buildroot}/usr/sbin/ceph-manage-journal
+
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
 %py3_compile %{buildroot}%{python3_sitelib}
@@ -1021,8 +1034,13 @@ rm -rf %{buildroot}
 %{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
 %{_bindir}/ceph-detect-init
+%{_sysconfdir}/ceph/ceph.conf.pmon
+%{_sysconfdir}/ceph/ceph_pmon_wrapper.sh
+%{_sysconfdir}/ceph/ceph.conf
+%{_sysconfdir}/services.d/*
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
 %{_sbindir}/ceph-create-keys
+%{_sbindir}/ceph-manage-journal
 %{_sbindir}/ceph-disk
 %dir %{_libexecdir}/ceph
 %{_libexecdir}/ceph/ceph_common.sh
@@ -1503,6 +1521,7 @@ fi
 %{_bindir}/ceph-objectstore-tool
 %{_bindir}/ceph-osdomap-tool
 %{_bindir}/ceph-osd
+%{_sbindir}/ceph-manage-journal
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %{_sbindir}/ceph-volume
 %{_sbindir}/ceph-volume-systemd

--- a/make-debs.sh
+++ b/make-debs.sh
@@ -33,7 +33,7 @@ git clean -dxf
 # c) compares higher than any previous commit
 # d) contains the short hash of the commit
 #
-vers=$(git describe --match "v*" | sed s/^v//)
+vers=`echo 'stx-ceph_v13.2.0' | sed 's/^stx-ceph_v//'`
 ./make-dist $vers
 #
 # rename the tarbal to match debian conventions and extract it

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -3,9 +3,7 @@
 #
 # Create a SRPM which can be used to build Ceph
 #
-# ./make-srpm.sh <version>
-# rpmbuild --rebuild /tmp/ceph/ceph-<version>-0.el7.centos.src.rpm
-#
 
-./make-dist $1
+vers=`echo 'stx-ceph_v13.2.0' | sed 's/^stx-ceph_v//'`
+./make-dist $ver
 rpmbuild -D"_sourcedir `pwd`" -D"_specdir `pwd`" -D"_srcrpmdir `pwd`" -bs ceph.spec

--- a/qa/standalone/special/ceph_objectstore_tool.py
+++ b/qa/standalone/special/ceph_objectstore_tool.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     DEVNULL = open(os.devnull, "wb")
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING, datafmt="%FT%T")
 
 
 if sys.version_info[0] >= 3:

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3196,8 +3196,7 @@ def mkfs(
                 '--monmap', monmap,
                 '--osd-data', path,
                 '--osd-uuid', fsid,
-                '--setuser', get_ceph_user(),
-                '--setgroup', get_ceph_group(),
+                 # don't run as ceph
             ],
         )
     elif osd_type == 'filestore':
@@ -3212,8 +3211,7 @@ def mkfs(
                 '--osd-data', path,
                 '--osd-journal', os.path.join(path, 'journal'),
                 '--osd-uuid', fsid,
-                '--setuser', get_ceph_user(),
-                '--setgroup', get_ceph_group(),
+                 # don't run as ceph
             ],
         )
     else:

--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -7,6 +7,55 @@ conf=$default_conf
 
 hostname=`hostname -s`
 
+wlog() {
+    # Syntax: "wlog <name> <err_lvl> <log_msg> [print_trace]"
+    # err_lvl should be INFO, WARN, ERROR or DEBUG
+    #  o INFO - state transitions & normal messages
+    #  o WARN - unexpected events (i.e. processes marked as down)
+    #  o ERROR - hang messages and unexpected errors
+    #  o DEBUG - print debug messages
+    if [ -z "$LOG_FILE" ] || [ "$LOG_LEVEL" != "DEBUG" ] && [ "$2" = "DEBUG" ]; then
+        # hide messages
+        return
+    fi
+
+    local head="$(date "+%Y-%m-%d %H:%M:%S.%3N") $0 $1"
+    echo "$head $2: $3" >> $LOG_FILE
+    if [ "$4" = "print_trace" ]; then
+        # Print out the stack trace
+        if [ ${#FUNCNAME[@]} -gt 1 ]; then
+            echo "$head   Call trace:" >> $LOG_FILE
+            for ((i=0;i<${#FUNCNAME[@]}-1;i++)); do
+                echo "$head     $i: ${BASH_SOURCE[$i+1]}:${BASH_LINENO[$i]} ${FUNCNAME[$i]}(...)" >> $LOG_FILE
+            done
+        fi
+    fi
+}
+
+CEPH_FAILURE=""
+execute_ceph_cmd() {
+    # execute a comand and in case it timeouts mark ceph as failed
+    local ret=$1
+    local name=$2
+    local cmd=$3
+    local cmd="timeout $WAIT_FOR_CMD $cmd"
+    set -o pipefail
+    eval "$cmd &>$DATA_PATH/.ceph_cmd_out"
+    errcode=$?
+    set +o pipefail
+    if [ -z "$output" ] && [ $errcode -eq 124 ]; then  # 'timeout' returns 124 when timing out
+        wlog $name "WARN" "Ceph failed to respond in ${WAIT_FOR_CMD}s when running: $cmd"
+        CEPH_FAILURE="true"
+        echo ""; return 1
+    fi
+    output=$(cat $DATA_PATH/.ceph_cmd_out)
+    if [ -z "$output" ] || [ $errcode -ne 0 ]; then
+        wlog $name "WARN" "Error executing: $cmd errorcode: $errcode output: $output"
+        echo ""; return 1
+    fi
+    eval "$ret=\"$output\""; return $errcode
+}
+
 verify_conf() {
     # fetch conf?
     if [ -x "$ETCDIR/fetch_config" ] && [ "$conf" = "$default_conf" ]; then
@@ -29,7 +78,6 @@ verify_conf() {
 	fi
     fi
 }
-
 
 check_host() {
     # what host is this daemon assigned to?
@@ -188,7 +236,7 @@ get_name_list() {
     $CCONF -c $conf -l mds | egrep -v '^mds$' >> $tmp || true
     $CCONF -c $conf -l mgr | egrep -v '^mgr$' >> $tmp || true
     $CCONF -c $conf -l osd | egrep -v '^osd$' >> $tmp || true
-    allconf=`sort -u $tmp`
+    allconf=`cat $tmp | xargs -n1 | sort -u | xargs`
     rm $tmp
 
     if [ -z "$orig" ]; then

--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -182,10 +182,14 @@ get_name_list() {
     orig="$*"
 
     # extract list of monitors, mdss, osds, mgrs defined in startup.conf
-    allconf="$local "`$CCONF -c $conf -l mon | egrep -v '^mon$' || true ; \
-	$CCONF -c $conf -l mds | egrep -v '^mds$' || true ; \
-	$CCONF -c $conf -l mgr | egrep -v '^mgr$' || true ; \
-	$CCONF -c $conf -l osd | egrep -v '^osd$' || true`
+    tmp=$(mktemp /tmp/ceph.XXXXXXX)
+    echo $local >> $tmp
+    $CCONF -c $conf -l mon | egrep -v '^mon$' >> $tmp || true
+    $CCONF -c $conf -l mds | egrep -v '^mds$' >> $tmp || true
+    $CCONF -c $conf -l mgr | egrep -v '^mgr$' >> $tmp || true
+    $CCONF -c $conf -l osd | egrep -v '^osd$' >> $tmp || true
+    allconf=`sort -u $tmp`
+    rm $tmp
 
     if [ -z "$orig" ]; then
 	what="$allconf"

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -13,7 +13,7 @@
 ### END INIT INFO
 
 # TODO: on FreeBSD/OSX, use equivalent script file
-if [ -e /lib/lsb/init-functions ]; then
+if [ -f /lib/lsb/init-functions ]; then
     . /lib/lsb/init-functions
 fi
 

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -447,6 +447,10 @@ for name in $what; do
 	    [ -n "$asok" ] && rm -f $asok
 	    [ -n "$post_stop" ] && do_cmd "$post_stop"
 	    [ -n "$lockfile" ] && [ "$?" -eq 0 ] && rm -f $lockfile
+	    # flush journal to data disk in background
+	    if [ "$type" == "osd" ];then
+	        $(/usr/bin/ceph-osd -i $id --flush-journal) &
+	    fi
 	    if [ $dofsumount -eq 1 ] && [ -n "$fs_devs" ]; then
 		echo Unmounting OSD volume on $host:$fs_path
 		do_root_cmd "umount $fs_path || true"
@@ -521,6 +525,11 @@ for name in $what; do
 	    ;;
     esac
 done
+
+# wait for journal flushing to complete
+if [ $command == "stop" ]; then
+    wait
+fi
 
 # activate latent osds?
 if [ "$command" = "start" -a "$BINDIR" != "." ]; then

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -38,10 +38,10 @@ else
 	echo "$LD_LIBRARY_PATH" | grep -q $CEPH_LIB || export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
 	echo "$DYLD_LIBRARY_PATH" | grep -q $CEPH_LIB || export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
     else
-	BINDIR=@bindir@
-	SBINDIR=@sbindir@
-	LIBEXECDIR=@libexecdir@/ceph
-	ETCDIR=@sysconfdir@/ceph
+	BINDIR=/usr/bin
+	SBINDIR=/usr/sbin
+	LIBEXECDIR=/usr/lib64/ceph
+	ETCDIR=/etc/ceph
 	ASSUME_DEV=0
     fi
 fi
@@ -53,6 +53,322 @@ if [ -n "$CEPH_BIN" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BUILD_DIR" ]; then
   LIBEXECDIR=$CEPH_ROOT/src
   ASSUME_DEV=1
 fi
+
+################################################
+#### WRS: Check if a ceph process is hung ####
+################################################
+
+# Each Ceph process has a state and a status.
+#  - States are used by the this script for decisions
+#  - Statuses are $UP or $DOWN and represent a process working state as reported by Ceph
+# OSD processes can have a status of "up" or "down" based on what Ceph is
+# reporting. We ignore the "in" status (we consider it as "Down")
+# Ceph processes states:
+# 1. STARTUP - a process is started but has not yet joined the cluster
+# 2. OPERATIONAL - a process joined the cluster
+# 3. HANGED - a process is hung
+# 4. STOPPED - a process is offline (/etc/init.d start was not executed)
+# Monitoring is done differently based on state
+# All timers are in seconds
+
+# FSM states
+ST_STARTUP="STARTED"
+ST_OPER="OPERATIONAL"
+ST_HANGED="HANGED"
+ST_STOPPED="STOPPED"
+
+# Ceph OSD status
+UP="up"
+DOWN="down"
+
+#paths
+source /usr/bin/tsconfig
+DATA_PATH=$VOLATILE_PATH/ceph_hang    # folder where we keep sate information
+LOG_PATH=/var/log/ceph
+LOG_FILE=$LOG_PATH/ceph-process-states.log
+mkdir -p $DATA_PATH         # make sure folder exists
+
+#timeouts
+WAIT_FOR_CMD=10                 # max wait for a response from Ceph
+WAIT_FOR_OSD_OPERATIONAL=300    # max wait for OSD to go 'up' when in startup state
+WAIT_FOR_OSD_DOWN_CONFIRM=30    # even if OSD is down it may be flapping, wait for a while
+WAIT_FOR_MON_OPERATIONAL=60     # max wait for MON to go 'up' when in startup state
+WAIT_FOR_MON_DOWN_CONFIRM=20    # even if MON is down it may be flapping, wait for a while
+
+LOG_LEVEL=NORMAL  # DEBUG
+
+save_proc_state() {
+    # Set the state of a process in the state machine and store it in a file
+    local name=$1
+    local state=$2
+    if [ "$state" != "$ST_STARTUP" ] && [ "$state" != "$ST_OPER" ] && \
+       [ "$state" != "$ST_HANGED" ] && [ "$state" != "$ST_STOPPED" ]; then
+        wlog $name "ERROR" "State $state is invalid, resetting to $ST_STARTUP" print_trace
+        state=$ST_STARTUP
+    fi
+    echo "$state" > ${DATA_PATH}/.${name}_state
+}
+
+load_proc_state() {
+    # Get the state of the state machine from file and validate content
+    local name=$1
+    local state=$ST_STARTUP
+    if [ -f ${DATA_PATH}/.${name}_state ]; then
+        state=$(cat ${DATA_PATH}/.${name}_state)
+    fi
+    if [ "$state" != "$ST_STARTUP" ] && [ "$state" != "$ST_OPER" ] && \
+       [ "$state" != "$ST_HANGED" ] && [ "$state" != "$ST_STOPPED" ]; then
+        wlog $name "ERROR" "State $state is invalid, resetting to $ST_STARTUP" print_trace
+        state=$ST_STARTUP
+        save_proc_state $name $state
+    fi
+    echo "$state"; return
+}
+
+save_proc_startup_ok() {
+    # Reset to initial state after a process started successfully (i.e. it has a valid pid)
+    local name=$1
+
+    # Process just started, clear all records, reset state
+    rm -f ${DATA_PATH}/.${name}_start_time
+    rm -f ${DATA_PATH}/.${name}_down_time
+    save_proc_state $name $ST_STARTUP
+
+    # Save the time when a process was started
+    wlog $name INFO "Process $ST_STARTUP successfully, waiting for it to become $ST_OPER"
+    echo $(date +%s) > ${DATA_PATH}/.${name}_start_time
+}
+
+save_proc_status() {
+    # Store the status of a process ($UP or $DOWN) and its start time
+    # Note that a process status is different from its states
+    local name=$1
+    local status=$2
+    if [ "$status" == $UP ]; then
+        rm -f ${DATA_PATH}/.${name}_down_time
+    else
+        if [ ! -f ${DATA_PATH}/.${name}_down_time ]; then
+            echo $(date +%s) > ${DATA_PATH}/.${name}_down_time
+        fi
+    fi
+}
+
+load_proc_status() {
+    # Load a process status ($UP or $DOWN)
+    local name=$1
+    if [ -f ${DATA_PATH}/.${name}_down_time ]; then
+        echo $DOWN
+    else
+        echo $UP
+    fi
+}
+
+get_duration(){
+    # Get duration based on file record and current time
+    local name=$1
+    local record=$2  # filename with prev time
+
+    # Check that we have a filename
+    if [ ! -f $record ]; then
+        wlog $name ERROR "Failed to compute duration, time was never stored in $record!" print_trace
+        echo "-1"; return
+    fi
+
+    # Get and validate time previously saved in file
+    local start_time=$(cat $record)
+    re="^[0-9]+$"
+    if ! [[ "$start_time" =~ $re ]] ; then
+       wlog $name ERROR "Recorded time '$start_time' is not a number!" print_trace
+       echo "-1"; return
+    fi
+
+    # Compute duration
+    local now=$(date +%s)
+    local duration=$((now-start_time))
+    if [ "$duration" -lt 0 ]; then
+        wlog $name ERROR "Duration less than 0!" print_trace
+        echo "-1"; return
+    fi
+    echo $duration
+}
+
+get_proc_run_time() {
+    local name=$1
+    local time=$(get_duration $name ${DATA_PATH}/.${name}_start_time)
+    wlog $name DEBUG ">>> process running for: ${time}s"
+    echo $time
+}
+
+get_proc_down_time() {
+    local name=$1
+    local time=$(get_duration $name ${DATA_PATH}/.${name}_down_time)
+    wlog $name DEBUG ">>> process down for: ${time}s"
+    echo $time
+}
+
+run_state_machine() {
+    # Small state machine, returns process state as defined in ST_* constants
+    # Same logic apply to both ceph-osd and ceph-mon, only timeouts are different
+    local name=$1       # 'osd.<number>' or 'mon.<hostname>'
+    local type=$2       # 'osd' or 'mon'
+    local status=$3     # daemon current status ($UP or $DOWN)
+    local wait_for_operational=$4  # how much time to wait for a process to go up
+    local wait_for_down_confirm=$5 # how much time to wait before reporting a process as down
+
+    local state=$(load_proc_state $name)
+
+    wlog $name "DEBUG" ">>>  state: $state"
+    # state machine
+    if [ "$state" = "$ST_STARTUP" ]; then
+        wlog $name "DEBUG" ">>> status: $status"
+        if [ "$status" = $UP ]; then
+            save_proc_state $name $ST_OPER
+            wlog $name "INFO" "Process is OPERATIONAL"
+            echo $ST_OPER; return
+        else
+            # the process should be 'up' in $WAIT_FOR_OSD_OPERATIONAL seconds!
+            if [ $(get_proc_run_time $name) -gt $wait_for_operational ]; then
+                # process hung!
+                wlog $name "ERROR" "Process failed to go up in ${wait_for_operational}s after start, reporting it as $ST_HANGED!"
+                save_proc_state $name $ST_HANGED
+                echo $ST_HANGED; return
+            fi
+        fi
+    elif [ "$state" = "$ST_OPER" ]; then
+        if [ "$status" = "$DOWN" ]; then
+            if [ $(load_proc_status $name) = $UP ];then
+                wlog $name "WARN" "Process went down!"
+                save_proc_status $name $DOWN
+            fi
+            # if a process is down we don't report it as hung for a while
+            # this should avoid status flapping
+            if [ $(get_proc_down_time $name) -gt $wait_for_down_confirm ]; then
+                # the process is down for a long time, report it as hung!
+                wlog $name "ERROR" "Process went down for more than ${wait_for_down_confirm}s, reporting it as $ST_HANGED"
+                save_proc_state $name $ST_HANGED
+                echo $ST_HANGED; return
+            fi
+        elif [ "$status" = "$UP" ]; then
+            if [ $(load_proc_status $name) = $DOWN ]; then
+                wlog $name "WARN" "Process went up, flapping status or busy process?"
+                save_proc_status $name $UP
+                return
+            fi
+        fi
+    elif [ "$state" = "$ST_HANGED" ] || [ "$state" = "$ST_STOPPED" ]; then
+        # nothing to do, resetting from these states is done externally in /etc/ceph/ceph_pmon_wrapper.sh
+        echo $state; return
+    fi
+}
+
+CEPH_FAILURE=""
+execute_ceph_cmd() {
+    # execute a comand and in case it timeouts mark ceph as failed
+    local name=$1
+    local cmd=$2
+    local cmd="timeout $WAIT_FOR_CMD $cmd"
+    set -o pipefail
+    eval "$cmd >$DATA_PATH/.ceph_cmd_out"
+    errcode=$?
+    set +o pipefail
+    if [ -z "$output" ] && [ $errcode -eq 124 ]; then  # 'timeout' returns 124 when timing out
+        wlog $name "WARN" "Ceph cluster failed to respond in ${WAIT_FOR_CMD}s when running: $cmd"
+        CEPH_FAILURE="true"
+        echo ""; return 1
+    fi
+    output=$(cat $DATA_PATH/.ceph_cmd_out)
+    if [ -z "$output" ] || [ $errcode -ne 0 ]; then
+        wlog $name "WARN" "Error executing: $cmd errorcode: $errcode output: $output"
+        echo ""; return 1
+    fi
+    echo "$output"; return $errcode
+}
+
+CEPH_OSD_TREE=""
+CEPH_HEALTH_DETAIL=""
+is_process_hung() {
+    local name=$1
+    local type=$2  # 'osd' or 'mon'
+
+    # Abort if we had previous errors with Ceph
+    if [ "$CEPH_FAILURE" = "true" ]; then
+        wlog $name "WARN" "Ceph cluster is marked as failed, aborting hang check"
+        echo "false"; return
+    fi
+
+    # Cache Ceph Health for later use as calling Ceph takes time
+    if [ -z "$CEPH_HEALTH_DETAIL" ]; then
+        execute_ceph_cmd CEPH_HEALTH_DETAIL $name "ceph health detail | tail -n 50"
+        if [ $? -ne 0 ]; then
+            wlog $name "WARN" "Aborting hang check"
+            echo "false"; return
+        fi
+    fi
+
+    # Check if an OSD is hung
+    if [ "$type" = "osd" ]; then
+        # Ignore health check if OSDs are administratively down
+        # Note this can be done with: 'ceph osd set noup; ceph osd down <osd.id>'
+        $(echo "$CEPH_HEALTH_DETAIL" | grep -q "^noup.*set")
+        if [ $? -eq 0 ]; then
+           wlog $name "WARN" "Ceph 'noup' flag is set, aborting hang check"
+           echo "false"; return
+        fi
+
+        # Multiple OSD processes may be running, so we only run
+        # 'ceph osd tree' once as it takes some time to execute
+        if [ -z "$CEPH_OSD_TREE" ]; then
+            execute_ceph_cmd CEPH_OSD_TREE $name "ceph osd tree"
+            if [ $? -ne 0 ]; then
+                wlog $name "WARN" "Ceph cmd exec failed, aborting hang check"
+                echo "false"; return
+            fi
+        fi
+
+        # Get osd status as 'up' or, for any other output, as 'down'
+        echo "$CEPH_OSD_TREE" | grep $name | grep -q "up"
+        if [ "$?" -eq 0 ]; then
+            osd_status=$UP
+        else
+            osd_status=$DOWN
+        fi
+
+        local state=$(run_state_machine $name $type $osd_status \
+                      $WAIT_FOR_OSD_OPERATIONAL $WAIT_FOR_OSD_DOWN_CONFIRM)
+        if [ "$state" = "$ST_HANGED" ]; then
+            echo "true"; return
+        else
+            echo "false"; return
+        fi
+
+
+     # Check if a Monitor is hung
+     elif [ "$type" = "mon" ]; then
+        # Get monitor status info
+        local mon_status=$UP
+        echo "$CEPH_HEALTH_DETAIL" | grep -q -e "^$name.*down"
+        if [ $? -eq 0 ]; then
+            mon_status=$DOWN
+        fi
+
+        local state=$(run_state_machine $name $type $mon_status \
+                      $WAIT_FOR_MON_OPERATIONAL $WAIT_FOR_MON_DOWN_CONFIRM)
+        if [ "$state" = "$ST_HANGED" ]; then
+            echo "true"; return
+        else
+            echo "false"; return
+        fi
+
+     else
+        wlog $name "WARN" "Unknown process type: $type"
+     fi
+   echo "false"
+}
+
+################
+#### WRS END ###
+################
+
 
 if [ `uname` = FreeBSD ]; then
   GETOPT=/usr/local/bin/getopt
@@ -133,11 +449,19 @@ stop_daemon() {
     pidfile=$3
     signal=$4
     action=$5
+    timeout=$6
     [ -z "$action" ] && action="Stopping"
     printf "$action Ceph $name on $host..."
     do_cmd "if [ -e $pidfile ] ; then 
-	pid=\`cat $pidfile\`
-	while ps -p \$pid -o args= | grep -q $daemon; do
+    pid=\`cat $pidfile\`
+    timeout=$timeout
+    while ps -p \$pid -o args= | grep -q $daemon; do
+	    if [ ! -z "$timeout" ]; then
+	        if [ \$timeout -lt 0 ]; then
+	            break
+	        fi
+	        timeout-=1
+	    fi
 	    cmd=\"kill $signal \$pid\"
 	    printf \"\$cmd...\"
 	    \$cmd
@@ -418,6 +742,8 @@ for name in $what; do
 		fi
 	    fi
 
+	    save_proc_startup_ok $name
+
 	    echo Starting Ceph $name on $host...
 	    if [ ! -d $run_dir ]; then
 		# assume /var/run exists
@@ -442,7 +768,21 @@ for name in $what; do
 	    get_conf pre_stop "" "pre stop command"
 	    get_conf post_stop "" "post stop command"
 	    [ -n "$pre_stop" ] && do_cmd "$pre_stop"
-	    stop_daemon $name ceph-$type $pid_file
+
+	    wlog $name "INFO" "Stopping process"
+
+	    if [ $(load_proc_state $name) != "$ST_HANGED" ]; then
+		stop_daemon $name ceph-$type $pid_file
+	    else
+		# first try to gracefully close process, this should be fast if
+		# its threads still respond to the TERM signal
+		wlog $name "DEBUG" ">>> Sending term signal"
+		stop_daemon $name ceph-$type $pid_file TERM "" 5
+		wlog $name "DEBUG" ">>> Sending kill signal"
+		# then just kill it
+		stop_daemon $name ceph-$type $pid_file KILL
+	    fi
+
 	    [ -n "$pidfile" ] && rm -f $pidfile
 	    [ -n "$asok" ] && rm -f $asok
 	    [ -n "$post_stop" ] && do_cmd "$post_stop"
@@ -451,6 +791,8 @@ for name in $what; do
 	    if [ "$type" == "osd" ];then
 	        $(/usr/bin/ceph-osd -i $id --flush-journal) &
 	    fi
+	    wlog $name "INFO" "Process stopped, setting state to $ST_STOPPED"
+	    save_proc_state $name $ST_STOPPED
 	    if [ $dofsumount -eq 1 ] && [ -n "$fs_devs" ]; then
 		echo Unmounting OSD volume on $host:$fs_path
 		do_root_cmd "umount $fs_path || true"
@@ -459,18 +801,30 @@ for name in $what; do
 
 	status)
 	    if daemon_is_running $name ceph-$type $id $pid_file; then
-		printf "$name: running "
-		do_cmd "$BINDIR/ceph daemon $name version 2>/dev/null" || printf unknown
-		printf "\n"
-            elif [ -e "$pid_file" ]; then
-                # daemon is dead, but pid file still exists
-                echo "$name: dead."
-                EXIT_STATUS=1
-            else
-                # daemon is dead, and pid file is gone
-                echo "$name: not running."
-                EXIT_STATUS=3
-            fi
+
+		# ceph processes answer in around 100ms when the process works correctly
+		do_cmd "timeout 1 $BINDIR/ceph --admin-daemon $asok version 2>/dev/null || echo unknown"
+
+		# check if daemon is hung
+		is_hung=$(is_process_hung $name $type)
+		if [ "$is_hung" = "true" ]; then
+		echo "$name: hung."
+		# based on http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
+		# exit codes from 150 to 199 are application specific, therefore we define one here
+		EXIT_STATUS=150
+		else
+		echo "$name: running."
+		fi
+
+	    elif [ -e "$pid_file" ]; then
+		# daemon is dead, but pid file still exists
+		echo "$name: dead."
+		EXIT_STATUS=1
+	    else
+		# daemon is dead, and pid file is gone
+		echo "$name: not running."
+		EXIT_STATUS=3
+	    fi
 	    ;;
 
 	ssh)

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -691,7 +691,8 @@ for name in $what; do
 
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
-	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster ${SET_CEPHUSER_ARGS} $runmode"
+	    # TIS: not running as ceph user/group
+	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster $runmode"
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then
 		get_conf pre_mount "true" "pre mount command"

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -330,8 +330,9 @@ class Error(Exception):
 
 
 class InvalidArgumentError(Error):
-    pass
-
+    def __init__(self, msg):
+        super(InvalidArgumentError, self).__init__(
+            ("RBD Invalid Argument error (%s)" % msg))
 
 class OSError(Error):
     """ `OSError` class, derived from `Error` """
@@ -350,73 +351,99 @@ class OSError(Error):
 
 class InterruptedOrTimeoutError(OSError):
     """ `InterruptedOrTimeoutError` class, derived from `OSError` """
-    pass
+    def __init__(self, msg):
+        super(InterruptedOrTimeoutError, self).__init__(
+            ("RBD Interrupted or Timeout error (%s)" % msg))
 
 
 class PermissionError(OSError):
     """ `PermissionError` class, derived from `OSError` """
-    pass
+    def __init__(self, msg):
+        super(PermissionError, self).__init__(
+            ("RBD Permission error (%s)" % msg))
 
 
 class PermissionDeniedError(OSError):
     """ deal with EACCES related. """
-    pass
+    def __init__(self, msg):
+        super(PermissionDeniedError, self).__init__(
+                ("RBD Permission Denied error (%s)" % msg))
 
 
 class ObjectNotFound(OSError):
     """ `ObjectNotFound` class, derived from `OSError` """
-    pass
-
+    def __init__(self, msg):
+        super(ObjectNotFound, self).__init__(
+                ("RBD Object Not Found error (%s)" % msg))
 
 class NoData(OSError):
     """ `NoData` class, derived from `OSError` """
-    pass
-
+    def __init__(self, msg):
+        super(NoData, self).__init__(
+                ("RBD No Data error (%s)" % msg))
 
 class ObjectExists(OSError):
     """ `ObjectExists` class, derived from `OSError` """
-    pass
-
+    def __init__(self, msg):
+        super(ObjectExists, self).__init__(
+                ("RBD Object Exists error (%s)" % msg))
 
 class ObjectBusy(OSError):
     """ `ObjectBusy` class, derived from `IOError` """
-    pass
+    def __init__(self, msg):
+        super(ObjectBusy, self).__init__(
+                ("RBD Object Busy error (%s)" % msg))
 
 
 class IOError(OSError):
     """ `ObjectBusy` class, derived from `OSError` """
-    pass
-
+    def __init__(self, msg):
+        super(IOError, self).__init__(
+                ("RBD I/O error (%s)" % msg))
 
 class NoSpace(OSError):
     """ `NoSpace` class, derived from `OSError` """
-    pass
-
+    def __init__(self, msg):
+        super(NoSpace, self).__init__(
+                ("RBD No Space error (%s)" % msg))
 
 class RadosStateError(Error):
     """ `RadosStateError` class, derived from `Error` """
-    pass
-
+    def __init__(self, msg):
+        super(RadosStateError, self).__init__(
+                ("RBD Rados State error (%s)" % msg))
 
 class IoctxStateError(Error):
     """ `IoctxStateError` class, derived from `Error` """
-    pass
-
+    def __init__(self, msg):
+        super(IoctxStateError, self).__init__(
+                ("RBD Ioctx State error (%s)" % msg))
 
 class ObjectStateError(Error):
     """ `ObjectStateError` class, derived from `Error` """
-    pass
-
+    def __init__(self, msg):
+        super(ObjectStateError, self).__init__(
+                ("RBD Object State error (%s)" % msg))
 
 class LogicError(Error):
     """ `` class, derived from `Error` """
-    pass
-
+    def __init__(self, msg):
+        super(LogicError, self).__init__(
+            ("RBD Logic error (%s)" % msg))
 
 class TimedOut(OSError):
     """ `TimedOut` class, derived from `OSError` """
+    def __init__(self, msg):
+        super(TimedOut, self).__init__(
+                ("RBD Timed Out error (%s)" % msg))
+
+class InProgress(Exception):
+    """ `InProgress` class, derived from `Error` """
     pass
 
+class IsConnected(Error):
+    """ `IsConnected` class, derived from `Error` """
+    pass
 
 IF UNAME_SYSNAME == "FreeBSD":
     cdef errno_to_exception = {
@@ -430,6 +457,8 @@ IF UNAME_SYSNAME == "FreeBSD":
         errno.EINTR     : InterruptedOrTimeoutError,
         errno.ETIMEDOUT : TimedOut,
         errno.EACCES    : PermissionDeniedError,
+        errno.EINPROGRESS : InProgress,
+        errno.EISCONN   : IsConnected,
         errno.EINVAL    : InvalidArgumentError,
     }
 ELSE:
@@ -444,6 +473,8 @@ ELSE:
         errno.EINTR     : InterruptedOrTimeoutError,
         errno.ETIMEDOUT : TimedOut,
         errno.EACCES    : PermissionDeniedError,
+        errno.EINPROGRESS : InProgress,
+        errno.EISCONN   : IsConnected,
         errno.EINVAL    : InvalidArgumentError,
     }
 
@@ -880,7 +911,7 @@ Rados object in state %s." % self.state)
         # for now and remove it later
         with nogil:
             ret = rados_connect(self.cluster)
-        if ret != 0:
+        if (ret != 0 and ret != -errno.EISCONN):
             raise make_ex(ret, "error connecting to the cluster")
         self.state = "connected"
 

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -332,7 +332,7 @@ class Error(Exception):
 class InvalidArgumentError(Error):
     def __init__(self, msg):
         super(InvalidArgumentError, self).__init__(
-            ("RBD Invalid Argument error (%s)" % msg))
+            ("RADOS Invalid Argument error (%s)" % msg))
 
 class OSError(Error):
     """ `OSError` class, derived from `Error` """
@@ -353,97 +353,101 @@ class InterruptedOrTimeoutError(OSError):
     """ `InterruptedOrTimeoutError` class, derived from `OSError` """
     def __init__(self, msg):
         super(InterruptedOrTimeoutError, self).__init__(
-            ("RBD Interrupted or Timeout error (%s)" % msg))
+            ("RADOS Interrupted or Timeout error (%s)" % msg))
 
 
 class PermissionError(OSError):
     """ `PermissionError` class, derived from `OSError` """
     def __init__(self, msg):
         super(PermissionError, self).__init__(
-            ("RBD Permission error (%s)" % msg))
+            ("RADOS Permission error (%s)" % msg))
 
 
 class PermissionDeniedError(OSError):
     """ deal with EACCES related. """
     def __init__(self, msg):
         super(PermissionDeniedError, self).__init__(
-                ("RBD Permission Denied error (%s)" % msg))
+                ("RADOS Permission Denied error (%s)" % msg))
 
 
 class ObjectNotFound(OSError):
     """ `ObjectNotFound` class, derived from `OSError` """
     def __init__(self, msg):
         super(ObjectNotFound, self).__init__(
-                ("RBD Object Not Found error (%s)" % msg))
+                ("RADOS Object Not Found error (%s)" % msg))
 
 class NoData(OSError):
     """ `NoData` class, derived from `OSError` """
     def __init__(self, msg):
         super(NoData, self).__init__(
-                ("RBD No Data error (%s)" % msg))
+                ("RADOS No Data error (%s)" % msg))
 
 class ObjectExists(OSError):
     """ `ObjectExists` class, derived from `OSError` """
     def __init__(self, msg):
         super(ObjectExists, self).__init__(
-                ("RBD Object Exists error (%s)" % msg))
+                ("RADOS Object Exists error (%s)" % msg))
 
 class ObjectBusy(OSError):
     """ `ObjectBusy` class, derived from `IOError` """
     def __init__(self, msg):
         super(ObjectBusy, self).__init__(
-                ("RBD Object Busy error (%s)" % msg))
+                ("RADOS Object Busy error (%s)" % msg))
 
 
 class IOError(OSError):
     """ `ObjectBusy` class, derived from `OSError` """
     def __init__(self, msg):
         super(IOError, self).__init__(
-                ("RBD I/O error (%s)" % msg))
+                ("RADOS I/O error (%s)" % msg))
 
 class NoSpace(OSError):
     """ `NoSpace` class, derived from `OSError` """
     def __init__(self, msg):
         super(NoSpace, self).__init__(
-                ("RBD No Space error (%s)" % msg))
+                ("RADOS No Space error (%s)" % msg))
 
 class RadosStateError(Error):
     """ `RadosStateError` class, derived from `Error` """
     def __init__(self, msg):
         super(RadosStateError, self).__init__(
-                ("RBD Rados State error (%s)" % msg))
+                ("RADOS Rados State error (%s)" % msg))
 
 class IoctxStateError(Error):
     """ `IoctxStateError` class, derived from `Error` """
     def __init__(self, msg):
         super(IoctxStateError, self).__init__(
-                ("RBD Ioctx State error (%s)" % msg))
+                ("RADOS Ioctx State error (%s)" % msg))
 
 class ObjectStateError(Error):
     """ `ObjectStateError` class, derived from `Error` """
     def __init__(self, msg):
         super(ObjectStateError, self).__init__(
-                ("RBD Object State error (%s)" % msg))
+                ("RADOS Object State error (%s)" % msg))
 
 class LogicError(Error):
     """ `` class, derived from `Error` """
     def __init__(self, msg):
         super(LogicError, self).__init__(
-            ("RBD Logic error (%s)" % msg))
+            ("RADOS Logic error (%s)" % msg))
 
 class TimedOut(OSError):
     """ `TimedOut` class, derived from `OSError` """
     def __init__(self, msg):
         super(TimedOut, self).__init__(
-                ("RBD Timed Out error (%s)" % msg))
+                ("RADOS Timed Out error (%s)" % msg))
 
 class InProgress(Exception):
     """ `InProgress` class, derived from `Error` """
-    pass
+    def __init__(self, msg):
+        super(InProgress, self).__init__(
+                ("RADOS In Progress error (%s)" %msg))
 
 class IsConnected(Error):
     """ `IsConnected` class, derived from `Error` """
-    pass
+    def __init__(self, msg):
+        super(IsConnected, self).__init__(
+                ("RADOS Is Connected error (%s)" %msg))
 
 IF UNAME_SYSNAME == "FreeBSD":
     cdef errno_to_exception = {

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -540,72 +540,94 @@ class OSError(Error):
         return (self.__class__, (self.message, self.errno))
 
 class PermissionError(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(PermissionError, self).__init__(
+                ("RBD permission error (%s)" % msg))
 
 class ImageNotFound(OSError):
-    pass
+    def __init__(self, msg):
+        super(ImageNotFound, self).__init__(
+                ("RBD image not found (%s)" % msg))
 
 class ObjectNotFound(OSError):
-    pass
+    def __init__(self, msg):
+        super(ObjectNotFound, self).__init__(
+                ("RBD object not found (%s)" % msg))
 
 class ImageExists(OSError):
-    pass
+    def __init__(self, msg):
+        super(ImageExists, self).__init__(
+                ("RBD image already exists (%s)" %msg))
 
 class ObjectExists(OSError):
     pass
 
 
 class IOError(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(IOError, self).__init__(
+                ("RBD I/O error (%s)" %msg))
 
 class NoSpace(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(NoSpace, self).__init__(
+                ("RBD insufficient space available (%s)" %
+                 msg))
 
 class IncompleteWriteError(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(IncompleteWriteError, self).__init__(
+               ("RBD incomplete write error (%s)" % msg))
 
 class InvalidArgument(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(InvalidArgument, self).__init__(
+                ("RBD invalid argument (%s)" % msg))
 
 class LogicError(Error):
-    pass
-
+    def __init__(self, msg):
+        super(LogicError, self).__init__(
+                ("RBD logic error (%s)" % msg))
 
 class ReadOnlyImage(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(ReadOnlyImage, self).__init__(
+                ("RBD read-only image (%s)" % msg))
 
 class ImageBusy(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(ImageBusy, self).__init__(
+                "RBD image is busy")
 
 class ImageHasSnapshots(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(ImageHasSnapshots, self).__init__(
+                ("RBD image has snapshots (%s)" % msg))
 
 class FunctionNotSupported(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(FunctionNotSupported, self).__init__(
+                ("RBD function not supported (%s)" % msg))
 
 class ArgumentOutOfRange(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(ArgumentOutOfRange, self).__init__(
+                ("RBD arguments out of range (%s)" % msg))
 
 class ConnectionShutdown(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(ConnectionShutdown, self).__init__(
+                ("RBD connection was shutdown (%s)" % msg))
 
 class Timeout(OSError):
-    pass
+    def __init__(self, msg):
+        super(Timeout, self).__init__(
+                ("RBD operation timeout (%s)" % msg))
 
 class DiskQuotaExceeded(OSError):
-    pass
-
+    def __init__(self, msg):
+        super(DiskQuotaExceeded, self).__init__(
+                ("RBD Disk Quota Exceeded (%s)" % msg))
 
 cdef errno_to_exception = {
     errno.EPERM     : PermissionError,

--- a/wrs/ceph-manage-journal.py
+++ b/wrs/ceph-manage-journal.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2016 Wind River Systems, Inc.
+#
+# The right to copy, distribute, modify, or otherwise make use
+# of this software may be licensed only pursuant to the terms
+# of an applicable Wind River license agreement.
+#
+
+import ast
+import os
+import os.path
+import re
+import subprocess
+import sys
+
+
+#########
+# Utils #
+#########
+
+def command(arguments, **kwargs):
+    """ Execute e command and capture stdout, stderr & return code """
+    process = subprocess.Popen(
+        arguments,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs)
+    out, err = process.communicate()
+    return out, err, process.returncode
+
+
+def get_input(arg, valid_keys):
+    """Convert the input to a dict and perform basic validation"""
+    json_string = arg.replace("\\n", "\n")
+    try:
+        input_dict = ast.literal_eval(json_string)
+        if not all(k in input_dict for k in valid_keys):
+            return None
+    except Exception:
+        return None
+
+    return input_dict
+
+
+def get_partition_uuid(dev):
+    output, _, _ = command(['blkid', dev])
+    try:
+        return re.search('PARTUUID=\"(.+?)\"', output).group(1)
+    except AttributeError:
+        return None
+
+
+###########################################
+# Manage Journal Disk Partitioning Scheme #
+###########################################
+
+DISK_BY_PARTUUID = "/dev/disk/by-partuuid/"
+
+def is_partitioning_correct(disk_node, partition_sizes):
+    """ Validate the existence and size of journal partitions"""
+
+    # Check that partition table format is GPT
+    output, _, _ = command(["udevadm", "settle", "-E", disk_node])
+    output, _, _ = command(["parted", "-s", disk_node, "print"])
+    if not re.search('Partition Table: gpt', output):
+        print "Format of disk node %s is not GPT, zapping disk" % disk_node
+        return False
+
+    # Check each partition size
+    partition_index = 1
+    for size in partition_sizes:
+        # Check that each partition size matches the one in input
+        partition_node = disk_node + str(partition_index)
+        output, _, _ = command(["udevadm", "settle", "-E", partition_node])
+        cmd = ["parted", "-s", partition_node, "unit", "MiB", "print"]
+        output, _, _ = command(cmd)
+
+        regex = ("^Disk " + str(partition_node) + ":\\s*" +
+                 str(size) + "[\\.0]*MiB")
+        if not re.search(regex, output, re.MULTILINE):
+            print ("Journal partition %(node)s size is not %(size)s, "
+                   "zapping disk" % {"node": partition_node, "size": size})
+            return False
+
+        partition_index += 1
+
+    output, _, _ = command(["udevadm", "settle", "-t", "10"])
+    return True
+
+
+def create_partitions(disk_node, partition_sizes):
+    """ Recreate partitions """
+
+    # CGTS-4320: After creating a new partition table on a device, Udev does not
+    # always remove old symlinks (i.e. to previous partitions on that device).
+    # Also, even if links are erased before zapping the disk, some of them will
+    # be recreated even though there is no partition to back them!
+    # Therefore, we have to remove the links AFTER we erase the partition table
+    # CGTS-4565: DISK_BY_PARTUUID directory is not present at all if there are no
+    # GPT partitions on the storage node so nothing to remove in this case
+    links = []
+    if os.path.isdir(DISK_BY_PARTUUID):
+        links = [ os.path.join(DISK_BY_PARTUUID,l) for l in os.listdir(DISK_BY_PARTUUID)
+                   if os.path.islink(os.path.join(DISK_BY_PARTUUID, l)) ]
+
+    # Erase all partitions on current node by creating a new GPT table
+    _, err, ret = command(["parted", "-s", disk_node, "mktable", "gpt"])
+    if ret:
+        print ("Error erasing partition table of %(node)s\n"
+               "Return code: %(ret)s reason: %(reason)s" %
+               {"node": disk_node, "ret": ret, "reason": err})
+        exit(1)
+
+    # Erase old symlinks
+    for l in links:
+        if disk_node in os.path.realpath(l):
+            os.remove(l)
+
+    # Create partitions in order
+    used_space_mib = 1  # leave 1 MB at the beginning of the disk
+    for size in partition_sizes:
+        cmd = ['parted', '-s', disk_node, 'unit', 'mib',
+               'mkpart', 'primary',
+               str(used_space_mib), str(used_space_mib + size)]
+        _, err, ret = command(cmd)
+        parms = {"disk_node": disk_node,
+                 "start": used_space_mib,
+                 "end": used_space_mib + size,
+                 "reason": err}
+        print ("Created partition from start=%(start)s MiB to end=%(end)s MiB"
+               " on %(disk_node)s" % parms)
+        if ret:
+            print ("Failed to create partition with "
+                   "start=%(start)s, end=%(end)s "
+                   "on %(disk_node)s reason: %(reason)s" % parms)
+            exit(1)
+        used_space_mib += size
+
+###########################
+# Manage Journal Location #
+###########################
+
+OSD_PATH = "/var/lib/ceph/osd/"
+
+
+def mount_data_partition(data_node, osdid):
+    """ Mount an OSD data partition and return the mounted path """
+    mount_path = OSD_PATH + "ceph-" + str(osdid)
+    output, _, _ = command(['mount'])
+    regex = "^" + data_node + ".*" + mount_path
+    if not re.search(regex, output, re.MULTILINE):
+        cmd = ['mount', '-t', 'xfs', data_node, mount_path]
+        _, _, ret = command(cmd)
+        params = {"node": data_node, "path": mount_path}
+        if ret:
+            print "Failed to mount %(node)s to %(path), aborting" % params
+            exit(1)
+        else:
+            print "Mounted %(node)s to %(path)s" % params
+    return mount_path
+
+
+def is_location_correct(path, journal_node, osdid):
+    """ Check if location points to the correct device """
+    cur_node = os.path.realpath(path + "/journal")
+    if cur_node == journal_node:
+        return True
+    else:
+        return False
+
+
+def fix_location(mount_point, journal_node, osdid):
+    """ Move the journal to the new partition """
+    # Fix symlink
+    path = mount_point + "/journal"  # 'journal' symlink path used by ceph-osd
+    new_target = DISK_BY_PARTUUID + get_partition_uuid(journal_node)
+    params = {"path": path, "target": new_target}
+    try:
+        if os.path.lexists(path):
+            os.unlink(path)  # delete the old symlink
+        os.symlink(new_target, path)
+        print "Symlink created: %(path)s -> %(target)s" % params
+    except:
+        print "Failed to create symlink: %(path)s -> %(target)s" % params
+        exit(1)
+
+    # Clean the journal partition
+    # even if erasing the partition table, is another journal was present here
+    # it's going to be reused. Journals are always bigger than 100MB
+    command(['dd', 'if=/dev/zero', 'of=%s' % journal_node,
+             'bs=1M', 'count=100'])
+
+    # Format the journal
+    cmd = ['/usr/bin/ceph-osd', '-i', str(osdid),
+           '--pid-file', '/var/run/ceph/osd.%s.pid' % osdid,
+           '-c', '/etc/ceph/ceph.conf',
+           '--cluster', 'ceph',
+           '--mkjournal']
+    out, err, ret = command(cmd)
+    params = {"journal_node": journal_node,
+              "osdid": osdid,
+              "ret": ret,
+              "reason": err}
+    if not ret:
+        print ("Prepared new journal partition: %(journal_node)s "
+               "for osd id: %(osdid)s") % params
+    else:
+        print ("Error initializing journal node: "
+               "%(journal_node)s for osd id: %(osdid)s "
+               "ceph-osd return code: %(ret)s reason: %(reason)s" % params)
+
+
+########
+# Main #
+########
+
+def main(argv):
+    # parse and validate arguments
+    err = False
+    partitions = None
+    location = None
+    if len(argv) != 2:
+        err = True
+    elif argv[0] == "partitions":
+        valid_keys = ['disk_node', 'journals']
+        partitions = get_input(argv[1], valid_keys)
+        if not partitions:
+            err = True
+        elif not isinstance(partitions['journals'], list):
+            err = True
+    elif argv[0] == "location":
+        valid_keys = ['data_node', 'journal_node', 'osdid']
+        location = get_input(argv[1], valid_keys)
+        if not location:
+            err = True
+        elif not isinstance(location['osdid'], int):
+            err = True
+    else:
+        err = True
+    if err:
+        print "Command intended for internal use only"
+        exit(-1)
+
+    if partitions:
+        # Recreate partitions only if the existing ones don't match input
+        if not is_partitioning_correct(partitions['disk_node'],
+                                       partitions['journals']):
+            create_partitions(partitions['disk_node'], partitions['journals'])
+        else:
+            print ("Partition table for %s is correct, "
+                   "no need to repartition" % partitions['disk_node'])
+    elif location:
+        # we need to have the data partition mounted & we can let it mounted
+        mount_point = mount_data_partition(location['data_node'],
+                                           location['osdid'])
+        # Update journal location only if link point to another partition
+        if not is_location_correct(mount_point,
+                                   location['journal_node'],
+                                   location['osdid']):
+            print ("Fixing journal location for "
+                   "OSD id: %(id)s" % {"node": location['data_node'],
+                                       "id": location['osdid']})
+            fix_location(mount_point,
+                         location['journal_node'],
+                         location['osdid'])
+        else:
+            print ("Journal location for %s is correct,"
+                   "no need to change it" % location['data_node'])
+
+main(sys.argv[1:])

--- a/wrs/ceph-radosgw.service
+++ b/wrs/ceph-radosgw.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=radosgw RESTful rados gateway
+After=network.target
+#After=remote-fs.target nss-lookup.target network-online.target time-sync.target
+#Wants=network-online.target
+
+[Service]
+Type=forking
+Restart=no
+KillMode=process
+RemainAfterExit=yes
+ExecStart=/etc/rc.d/init.d/ceph-radosgw start
+ExecStop=/etc/rc.d/init.d/ceph-radosgw stop
+ExecReload=/etc/rc.d/init.d/ceph-radosgw reload
+
+[Install]
+WantedBy=multi-user.target

--- a/wrs/ceph-rest-api
+++ b/wrs/ceph-rest-api
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          ceph-rest-api
+# Required-Start:    $ceph
+# Required-Stop:     $ceph
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Ceph REST API daemon
+# Description:       Ceph REST API daemon
+### END INIT INFO
+
+DESC="ceph-rest-api"
+DAEMON="/usr/bin/ceph-rest-api"
+RUNDIR="/var/run/ceph"
+PIDFILE="${RUNDIR}/ceph-rest-api.pid"
+
+start()
+{
+    if [ -e $PIDFILE ]; then
+        PIDDIR=/proc/$(cat $PIDFILE)
+        if [ -d ${PIDDIR} ]; then
+            echo "$DESC already running."
+            exit 0
+        else
+            echo "Removing stale PID file $PIDFILE"
+            rm -f $PIDFILE
+        fi
+    fi
+
+    echo -n "Starting $DESC..."
+    mkdir -p $RUNDIR
+    start-stop-daemon --start --quiet --background \
+        --pidfile ${PIDFILE} --make-pidfile --exec ${DAEMON}
+
+    if [ $? -eq 0 ]; then
+        echo "done."
+    else
+        echo "failed."
+        exit 1
+    fi
+}
+
+stop()
+{
+    echo -n "Stopping $DESC..."
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE
+    if [ $? -eq 0 ]; then
+        echo "done."
+    else
+        echo "failed."
+    fi
+    rm -f $PIDFILE
+}
+
+status()
+{
+    pid=`cat $PIDFILE 2>/dev/null`
+    if [ -n "$pid" ]; then
+        if ps -p $pid &>/dev/null ; then
+            echo "$DESC is running"
+            exit 0
+        else
+            echo "$DESC is not running but has pid file"
+            exit 1
+        fi
+    fi
+    echo "$DESC is not running"
+    exit 3
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|force-reload|reload)
+        stop
+        start
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|force-reload|restart|reload|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/wrs/ceph-rest-api.service
+++ b/wrs/ceph-rest-api.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ceph REST API
+After=network.target ceph.target
+
+[Service]
+Type=forking
+Restart=no
+KillMode=process
+RemainAfterExit=yes
+ExecStart=/etc/rc.d/init.d/ceph-rest-api start
+ExecStop=/etc/rc.d/init.d/ceph-rest-api stop
+ExecReload=/etc/rc.d/init.d/ceph-rest-api reload
+
+[Install]
+WantedBy=multi-user.target

--- a/wrs/ceph.conf
+++ b/wrs/ceph.conf
@@ -1,0 +1,43 @@
+[global]
+	# Unique ID for the cluster.
+	fsid = %CLUSTER_UUID%
+	# Public network where the monitor is connected to, i.e, 128.224.0.0/16
+	#public network = 127.0.0.1/24
+	# For version 0.55 and beyond, you must explicitly enable
+	# or disable authentication with "auth" entries in [global].
+	auth_cluster_required = cephx
+	auth_service_required = cephx
+	auth_client_required = cephx
+	osd_journal_size = 1024
+
+	# Uncomment the following line if you are mounting with ext4
+	# filestore xattr use omap = true
+
+	# Number of replicas of objects. Write an object 2 times.
+	# Cluster cannot reach an active + clean state until there's enough OSDs
+	# to handle the number of copies of an object. In this case, it requires
+	# at least 2 OSDs
+	osd_pool_default_size = 2
+
+	# Allow writing one copy in a degraded state.
+	osd_pool_default_min_size = 1
+
+	# Ensure you have a realistic number of placement groups. We recommend
+	# approximately 100 per OSD. E.g., total number of OSDs multiplied by 100
+	# divided by the number of replicas (i.e., osd pool default size). So for
+	# 2 OSDs and osd pool default size = 2, we'd recommend approximately
+	# (100 * 2) / 2 = 100.
+	osd_pool_default_pg_num = 64
+	osd_pool_default_pgp_num = 64
+	osd_crush_chooseleaf_type = 1
+
+[osd]
+	osd_mkfs_type = xfs
+	osd_mkfs_options_xfs = "-f"
+	osd_mount_options_xfs = "rw,noatime,inode64,logbufs=8,logbsize=256k"
+
+[mon]
+    mon warn on legacy crush tunables = false
+    # Quiet new warnings on move to Hammer
+    mon pg warn max per osd = 2048
+    mon pg warn max object skew = 0

--- a/wrs/ceph.conf
+++ b/wrs/ceph.conf
@@ -30,6 +30,7 @@
 	osd_pool_default_pg_num = 64
 	osd_pool_default_pgp_num = 64
 	osd_crush_chooseleaf_type = 1
+	setuser match path = /var/lib/ceph/$type/$cluster-$id
 
 [osd]
 	osd_mkfs_type = xfs

--- a/wrs/ceph.conf.pmon
+++ b/wrs/ceph.conf.pmon
@@ -1,0 +1,26 @@
+[process]
+process  = ceph
+script   = /etc/ceph/ceph_pmon_wrapper.sh
+
+style    = lsb
+severity = major          ; minor, major, critical
+restarts = 3              ; restart retries before error assertion
+interval = 30             ; number of seconds to wait between restarts
+
+mode = status             ; Monitoring mode: passive (default) or active
+                          ; passive: process death monitoring (default: always)
+                          ; active : heartbeat monitoring, i.e. request / response messaging
+                          ; status : determine process health with executing "status" command
+                          ;          "start" is used to start the process(es) again
+                          ; ignore : do not monitor or stop monitoring
+
+; Status and Active Monitoring Options
+
+period     = 30           ; monitor period in seconds
+timeout    = 120          ; for active mode, messaging timeout period in seconds, must be shorter than period
+                          ; for status mode, max amount of time for a command to execute
+
+; Status Monitoring Options
+start_arg      = start        ; start argument for the script
+status_arg     = status       ; status argument for the script
+status_failure_text = /tmp/ceph_status_failure.txt   ; text to be added to alarms or logs, this is optional

--- a/wrs/ceph.service
+++ b/wrs/ceph.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ceph Startup
+After=network.target
+
+[Service]
+Type=forking
+Restart=no
+KillMode=process
+RemainAfterExit=yes
+ExecStart=/etc/rc.d/init.d/ceph start
+ExecStop=/etc/rc.d/init.d/ceph stop
+PIDFile=/var/run/ceph/ceph.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/wrs/ceph.sh
+++ b/wrs/ceph.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+INITDIR=/etc/init.d
+LOGFILE=/var/log/ceph/ceph-init.log
+CEPH_FILE=/var/run/.ceph_started
+
+# Get our nodetype
+. /etc/platform/platform.conf
+
+# Exit immediately if ceph not configured (i.e. no mon in the config file)
+if ! grep -q "mon\." /etc/ceph/ceph.conf
+then
+    exit 0
+fi
+
+logecho ()
+{
+    echo $1
+    date >> ${LOGFILE}
+    echo $1 >> ${LOGFILE}
+}
+
+start ()
+{
+    if [[ "$nodetype" == "controller" ]] || [[ "$nodetype" == "storage" ]]
+    then
+        logecho "Starting ceph services..."
+        ${INITDIR}/ceph start >> ${LOGFILE} 2>&1
+        RC=$?
+
+        if [ ! -f ${CEPH_FILE} ]
+        then
+            touch ${CEPH_FILE}
+        fi
+    else
+        logecho "No ceph services on ${nodetype} node"
+        exit 0
+    fi
+}
+
+stop ()
+{
+    if [[ "$nodetype" == "controller" ]] || [[ "$nodetype" == "storage" ]]
+    then
+        logecho "Stopping ceph services..."
+
+        if [ -f ${CEPH_FILE} ]
+        then
+            rm -f ${CEPH_FILE}
+        fi
+
+        ${INITDIR}/ceph stop >> ${LOGFILE} 2>&1
+        RC=$?
+    else
+        logecho "No ceph services on ${nodetype} node"
+        exit 0
+    fi
+}
+
+RC=0
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac
+
+logecho "RC was: $RC"
+exit $RC

--- a/wrs/ceph_pmon_wrapper.sh
+++ b/wrs/ceph_pmon_wrapper.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# Copyright (c) 2015-2016 Wind River Systems, Inc.
+#
+# The right to copy, distribute, modify, or otherwise make use
+# of this software may be licensed only pursuant to the terms
+# of an applicable Wind River license agreement.
+#
+# This script is a helper wrapper for pmon monitoring of ceph
+# processes. The "/etc/init.d/ceph" script does not know if ceph is
+# running on the node. For example when the node is locked, ceph
+# processes are not running. In that case we do not want pmond to
+# monitor these processes.
+#
+# The script "/etc/services.d/<node>/ceph.sh" will create the file
+# "/var/run/.ceph_started" when ceph is running and remove it when
+# is not.
+#
+# The script also extracts  one or more ceph process names  that are
+# reported as 'not running' or 'dead' or 'failed'  by '/etc/intit.d/ceph status'
+# and writes the names to a text file: /tmp/ceph_status_failure.txt for
+# pmond to access. The pmond adds the text to logs and alarms. Example of text
+# samples written to file by this script are:
+#   'osd.1'
+#   'osd.1, osd.2'
+#   'mon.storage-0'
+#   'mon.storage-0, osd.2'
+#
+# Moreover, for processes that are reported as 'hung' by '/etc/intit.d/ceph status'
+# the script will try increase their logging to 'debug' for a configurable interval.
+# With logging increased it will outputs a few stack traces then, at the end of this
+# interval, it dumps its stack core and kills it.
+#
+# Return values;
+# zero -   /etc/init.d/ceph returned success or ceph is not running on the node
+# non-zero /etc/init.d/ceph returned a failure or invalid syntax
+#
+
+source /usr/bin/tsconfig
+
+CEPH_SCRIPT="/etc/init.d/ceph"
+CEPH_FILE="$VOLATILE_PATH/.ceph_started"
+CEPH_RESTARTING_FILE="$VOLATILE_PATH/.ceph_restarting"
+CEPH_GET_STATUS_FILE="$VOLATILE_PATH/.ceph_getting_status"
+CEPH_STATUS_FAILURE_TEXT_FILE="/tmp/ceph_status_failure.txt"
+
+BINDIR=/usr/bin
+SBINDIR=/usr/sbin
+LIBDIR=/usr/lib64/ceph
+ETCDIR=/etc/ceph
+COREDIR=/var/lib/systemd/coredump
+source $LIBDIR/ceph_common.sh
+
+LOG_PATH=/var/log/ceph
+LOG_FILE=$LOG_PATH/ceph-process-states.log
+LOG_LEVEL=NORMAL  # DEBUG
+verbose=0
+
+DATA_PATH=$VOLATILE_PATH/ceph_hang    # folder where we keep state information
+mkdir -p $DATA_PATH                   # make sure folder exists
+
+MONITORING_INTERVAL=15
+TRACE_LOOP_INTERVAL=5
+GET_STATUS_TIMEOUT=120
+
+WAIT_FOR_CMD=1
+
+RC=0
+
+wait_for_status ()
+{
+    timeout=$GET_STATUS_TIMEOUT  # wait for status no more than $timeout seconds
+    while [ -f ${CEPH_GET_STATUS_FILE} ] && [ $timeout -gt 0 ]
+    do
+       sleep 1
+       let timeout-=1
+    done
+    if [ $timeout -eq 0 ]
+    then
+        wlog "-" "WARN" "Getting status takes more than ${GET_STATUS_TIMEOUT}s, continuing"
+        rm -f $CEPH_GET_STATUS_FILE
+    fi
+}
+
+start ()
+{
+    if [ -f ${CEPH_FILE} ]
+    then
+        wait_for_status
+        ${CEPH_SCRIPT} start
+        RC=$?
+    else
+        # Ceph is not running on this node, return success
+        exit 0
+    fi
+}
+
+restart ()
+{
+    if [ -f ${CEPH_FILE} ]
+    then
+        wait_for_status
+        touch $CEPH_RESTARTING_FILE
+        ${CEPH_SCRIPT} restart
+        rm -f $CEPH_RESTARTING_FILE
+    else
+        # Ceph is not running on this node, return success
+        exit 0
+    fi
+
+}
+
+log_and_kill_hung_procs ()
+{
+    # Log info about the hung processes and then kill them; later on pmon will restart them
+    local names=$1
+    for name in $names;
+    do
+        type=`echo $name | cut -c 1-3`   # e.g. 'mon', if $item is 'mon1'
+        id=`echo $name | cut -c 4- | sed 's/^\\.//'`
+        get_conf run_dir "/var/run/ceph" "run dir"
+        get_conf pid_file "$run_dir/$type.$id.pid" "pid file"
+        pid=$(cat $pid_file)
+        wlog $name "INFO" "Dealing with hung process (pid:$pid)"
+
+        # monitoring interval
+        wlog $name "INFO" "Increasing log level"
+        execute_ceph_cmd ret $name "ceph daemon $name config set debug_$type 20/20"
+        monitoring=$MONITORING_INTERVAL
+        while [ $monitoring -gt 0 ]
+        do
+            if [ $(($monitoring % $TRACE_LOOP_INTERVAL)) -eq 0 ]; then
+                date=$(date "+%Y-%m-%d_%H-%M-%S")
+                log_file="$LOG_PATH/hang_trace_${name}_${pid}_${date}.log"
+                wlog $name "INFO" "Dumping stack trace to: $log_file"
+                $(pstack $pid >$log_file) &
+            fi
+            let monitoring-=1
+            sleep 1
+        done
+
+        core_file="$COREDIR/core.ceph-${type}.${UID}.$(cat /etc/machine-id).${pid}.$(date +%s%N)"
+        wlog $name "INFO" "Dumping core to: $core_file"
+        gcore -o $core_file $pid &>/dev/null
+        mv ${core_file}.$pid ${core_file}
+        wlog $name "INFO" "Archiving core file (in background)"
+        $(xz -z $core_file -T 8) &
+        wlog $name "INFO" "Killing process, it will be restarted by pmon..."
+        kill -KILL $pid &>/dev/null
+        rm -f $pid_file # process is dead, core dump is archiving, preparing for restart
+    done
+}
+
+status ()
+{
+    if [ -f ${CEPH_RESTARTING_FILE} ]
+    then
+        # Ceph is restarting, we don't report state changes on the first pass
+       rm -f ${CEPH_RESTARTING_FILE}
+       exit 0
+    fi
+    if [ -f ${CEPH_FILE} ]
+    then
+        # Make sure the script does not 'exit' between here and the 'rm -f' below
+        # or the checkpoint file will be left behind
+        touch -f ${CEPH_GET_STATUS_FILE}
+        result=`${CEPH_SCRIPT} status`
+        RC=$?
+        if [ "$RC" -ne 0 ]; then
+            erred_procs=`echo "$result" | sort | uniq | awk ' /not running|dead|failed/ {printf "%s ", $1}' | sed 's/://g' | sed 's/, $//g'`
+            hung_procs=`echo "$result" | sort | uniq | awk ' /hung/ {printf "%s ", $1}' | sed 's/://g' | sed 's/, $//g'`
+            invalid=0
+            host=`hostname`
+            for i in $(echo $erred_procs $hung_procs)
+            do
+               if [[ "$i" =~ osd.?[0-9]?[0-9]|mon.$host ]]; then
+                  continue
+               else
+                  invalid=1
+               fi
+            done
+
+            log_and_kill_hung_procs $hung_procs
+
+            hung_procs_text=""
+            for i in $(echo $hung_procs)
+            do
+                hung_procs_text+="$i(process hung) "
+            done
+
+            rm -f $CEPH_STATUS_FAILURE_TEXT_FILE
+            if [ $invalid -eq 0 ]; then
+                text=""
+                for i in $erred_procs
+                do
+                    text+="$i, "
+                done
+                for i in $hung_procs
+                do
+                    text+="$i (process hang), "
+                done
+                echo "$text" | tr -d '\n' > $CEPH_STATUS_FAILURE_TEXT_FILE
+            else
+               echo "$host: '${CEPH_SCRIPT} status' result contains invalid process names: $erred_procs"
+               echo "undetermined_osd" > $CEPH_STATUS_FAILURE_TEXT_FILE
+            fi
+        fi
+        rm -f ${CEPH_GET_STATUS_FILE}
+    else
+        # Ceph is not running on this node, return success
+        exit 0
+    fi
+}
+
+
+case "$1" in
+    start)
+        start
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo "Usage: $0 {start|restart|status}"
+        exit 1
+        ;;
+esac
+
+exit $RC


### PR DESCRIPTION
These patches are from Wind River which were merged in Intel internal code base of 10.2.6 Ceph for startlingx. We're porting these patches for stx-ceph upgrade from 10.2.6 to 13.2.0.
Please help review the patches.

Add .gitreview
Ceph Rebase: Changes for spec-include-TiS-changes.patch
Ceph Rebase: Changes for spec-disable-debuginfo-package.patch
Ceph Rebase: Changes for spec-add-init-script-patch.patch
Ceph Rebase: Changes for ceph-spec-add-service-files.patch
Ceph Rebase: Changes for tis-exclude-95-ceph-osd.rules-from-package.patch
Ceph Rebase: Changes for spec-Security-Gaps-File-permissions.patch
Ceph Rebase: Changes for fix-ceph-mon-started-twice.patch
Ceph Rebase: Changes for flag-ceph.conf-as-a-config-file.patch
Ceph Rebase: Changed for add-monitoring-and-recovery-of-hung-processe.patch
Ceph Rebase: Disable ceph user/group for Hammer equivalence.patch
Ceph Rebase: Add verbose rados and rbd exceptions.patch
There're some left patches that we're working on.